### PR TITLE
add 'map' as valid datatype

### DIFF
--- a/datacontract.schema.json
+++ b/datacontract.schema.json
@@ -1198,6 +1198,7 @@
         "object",
         "record",
         "struct",
+        "map",
         "bytes",
         "null"
       ]


### PR DESCRIPTION
in Databricks there is datatype 'map' for columns in a UnityCatalog table. After I created a datacontract, which includes the UnityCatalog table as "model", the linting of the datacontract fails....since 'map' is not in the list of valid types. Since I want to keep the original datatype, it would be great to have 'map' added.