### PR TITLE
Add additional configuration for addressing Redshift servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The public API SHOULD NOT be considered stable.
 - Trino support
 - Field `type: map` support with properties `keys` and `values`
 - Definitions: `fields`, for type `object`, `record`, and `struct`
+- Add Redshift server properties `clusterIdentifier`, `endpoint`, `host` and `port`.
 
 ## [0.9.3] - 2024-03-06
 

--- a/README.md
+++ b/README.md
@@ -426,6 +426,8 @@ Example, specifying an endpoint:
 servers:
   analytics:
     type: redshift
+    account: '123456789012'
+    database: analytics
     schema: analytics
     endpoint: analytics-cluster.example.eu-west-1.redshift.amazonaws.com:5439/analytics
 ```
@@ -437,10 +439,9 @@ servers:
   analytics:
     type: redshift
     account: '123456789012'
-    clusterIdentifier: analytics-cluster
     database: analytics
-    port: 5439
     schema: analytics
+    clusterIdentifier: analytics-cluster
 ```
 
 Example, specifying the cluster host:
@@ -449,10 +450,11 @@ Example, specifying the cluster host:
 servers:
   analytics:
     type: redshift
-    host: analytics-cluster.example.eu-west-1.redshift.amazonaws.com
+    account: '123456789012'
     database: analytics
-    port: 5439
     schema: analytics
+    host: analytics-cluster.example.eu-west-1.redshift.amazonaws.com
+    port: 5439
 ```
 
 #### Azure Server Object

--- a/README.md
+++ b/README.md
@@ -409,12 +409,51 @@ servers:
 
 #### Redshift Server Object
 
-| Field    | Type     | Description |
-|----------|----------|-------------|
-| type     | `string` | `redshift`  |
-| account  | `string` |             |
-| database | `string` |             |
-| schema   | `string` |             |
+| Field             | Type     | Description                                                                                                         |
+|-------------------|----------|---------------------------------------------------------------------------------------------------------------------|
+| type              | `string` | `redshift`                                                                                                          |
+| account           | `string` |                                                                                                                     |
+| database          | `string` |                                                                                                                     |
+| schema            | `string` |                                                                                                                     |
+| clusterIdentifier | `string` | Identifier of the cluster. <br /> Example: `analytics-cluster`                                                      |
+| host              | `string` | Host of the cluster. <br /> Example: `analytics-cluster.example.eu-west-1.redshift.amazonaws.com`                   |
+| port              | `number` | Port of the cluster. <br /> Example: `5439`                                                                         |
+| endpoint          | `string` | Endpoint of the cluster <br /> Example: `analytics-cluster.example.eu-west-1.redshift.amazonaws.com:5439/analytics` |
+
+Example, specifying an endpoint:
+
+```yaml
+servers:
+  analytics:
+    type: redshift
+    schema: analytics
+    endpoint: analytics-cluster.example.eu-west-1.redshift.amazonaws.com:5439/analytics
+```
+
+Example, specifying the cluster identifier:
+
+```yaml
+servers:
+  analytics:
+    type: redshift
+    account: '123456789012'
+    clusterIdentifier: analytics-cluster
+    database: analytics
+    port: 5439
+    schema: analytics
+```
+
+Example, specifying the cluster host:
+
+```yaml
+servers:
+  analytics:
+    type: redshift
+    host: analytics-cluster.example.eu-west-1.redshift.amazonaws.com
+    database: analytics
+    port: 5439
+    schema: analytics
+```
 
 #### Azure Server Object
 

--- a/datacontract.schema.json
+++ b/datacontract.schema.json
@@ -272,6 +272,10 @@
                 "type": "string",
                 "description": "An optional string describing the server."
               },
+              "host": {
+                "type": "string",
+                "description": "An optional string describing the host name."
+              },
               "database": {
                 "type": "string",
                 "description": "An optional string describing the server."
@@ -279,14 +283,40 @@
               "schema": {
                 "type": "string",
                 "description": "An optional string describing the server."
+              },
+              "clusterIdentifier": {
+                "type": "string",
+                "description": "An optional string describing the cluster's identifier.",
+                "examples": [
+                  "redshift-prod-eu",
+                  "analytics-cluster"
+                ]
+              },
+              "port": {
+                "type": "integer",
+                "description": "An optional string describing the cluster's port.",
+                "examples": [
+                  5439
+                ]
+              },
+              "endpoint": {
+                "type": "string",
+                "description": "An optional string describing the cluster's endpoint.",
+                "examples": [
+                  "analytics-cluster.example.eu-west-1.redshift.amazonaws.com:5439/analytics"
+                ]
               }
             },
             "additionalProperties": true,
             "required": [
               "type",
               "account",
+              "host",
               "database",
-              "schema"
+              "schema",
+              "clusterIdentifier",
+              "port",
+              "endpoint"
             ]
           },
           {

--- a/datacontract.schema.json
+++ b/datacontract.schema.json
@@ -311,12 +311,8 @@
             "required": [
               "type",
               "account",
-              "host",
               "database",
-              "schema",
-              "clusterIdentifier",
-              "port",
-              "endpoint"
+              "schema"
             ]
           },
           {


### PR DESCRIPTION
You cannot properly define a Redshift output port using the current specification. For example:

```yaml
example:
  type: redshift
  account: '123456789012' 
  database: analytics
  schema: analytics
```

The fragment only identifies the account the cluster is in, it doesn't provide the cluster’s identity.

My change adds the additional properties `clusterIdentifier`, `host`, `port` and `endpoint` to allow for more options when addressing Redshift output ports.

For example, using the `host` property:

```yaml
analytics:
  type: redshift
  account: '123456789012' 
  database: analytics
  schema: analytics
  host: analytics-cluster.example.eu-west-1.redshift.amazonaws.com
  port: 5439
```

I've also updated the README to add documentation, provide examples and corrected property descriptions.