### PR TITLE
datacontract.schema.json: allow many servers

### DIFF
--- a/datacontract.schema.json
+++ b/datacontract.schema.json
@@ -79,729 +79,737 @@
     },
     "servers": {
       "type": "object",
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "An optional string describing the servers."
-        },
-        "environment": {
-          "type": "string",
-          "description": "The environment in which the servers are running. Examples: prod, sit, stg."
-        }
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-zA-Z0-9_-]+$"
       },
       "additionalProperties": {
-        "oneOf": [
-          {
-            "type": "object",
-            "title": "BigQueryServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "bigquery",
-                  "BigQuery"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "project": {
-                "type": "string",
-                "description": "An optional string describing the server."
-              },
-              "dataset": {
-                "type": "string",
-                "description": "An optional string describing the server."
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "project",
-              "dataset"
-            ]
+        "type": "object",
+        "title": "Server",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "An optional string describing the servers."
           },
-          {
-            "type": "object",
-            "title": "S3Server",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "s3"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "location": {
-                "type": "string",
-                "format": "uri",
-                "description": "An optional string describing the server. Must be in the form of a URL.",
-                "examples": [
-                  "s3://datacontract-example-orders-latest/data/{model}/*.json"
-                ]
-              },
-              "endpointUrl": {
-                "type": "string",
-                "format": "uri",
-                "description": "The server endpoint for S3-compatible servers.",
-                "examples": ["https://minio.example.com"]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "parquet",
-                  "delta",
-                  "json",
-                  "csv"
-                ],
-                "description": "File format."
-              },
-              "delimiter": {
-                "type": "string",
-                "enum": [
-                  "new_line",
-                  "array"
-                ],
-                "description": "Only for format = json. How multiple json documents are delimited within one file"
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "location"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "GcsServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "gcs"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "location": {
-                "type": "string",
-                "format": "uri",
-                "description": "The GS/GCS url to the data.",
-                "examples": [
-                  "gs://example-storage/data/*/*.json"
-                ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "parquet",
-                  "delta",
-                  "json",
-                  "csv"
-                ],
-                "description": "File format."
-              },
-              "delimiter": {
-                "type": "string",
-                "enum": [
-                  "new_line",
-                  "array"
-                ],
-                "description": "Only for format = json. How multiple json documents are delimited within one file"
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "location"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "SftpServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "sftp"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "location": {
-                "type": "string",
-                "format": "uri",
-                "description": "An optional string describing the server. Must be in the form of a sftp URL.",
-                "examples": [
-                  "sftp://123.123.12.123/{model}/*.json"
-                ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "parquet",
-                  "delta",
-                  "json",
-                  "csv"
-                ],
-                "description": "File format."
-              },
-              "delimiter": {
-                "type": "string",
-                "enum": [
-                  "new_line",
-                  "array"
-                ],
-                "description": "Only for format = json. How multiple json documents are delimited within one file"
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "location"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "RedshiftServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "redshift"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "account": {
-                "type": "string",
-                "description": "An optional string describing the server."
-              },
-              "host": {
-                "type": "string",
-                "description": "An optional string describing the host name."
-              },
-              "database": {
-                "type": "string",
-                "description": "An optional string describing the server."
-              },
-              "schema": {
-                "type": "string",
-                "description": "An optional string describing the server."
-              },
-              "clusterIdentifier": {
-                "type": "string",
-                "description": "An optional string describing the cluster's identifier.",
-                "examples": [
-                  "redshift-prod-eu",
-                  "analytics-cluster"
-                ]
-              },
-              "port": {
-                "type": "integer",
-                "description": "An optional string describing the cluster's port.",
-                "examples": [
-                  5439
-                ]
-              },
-              "endpoint": {
-                "type": "string",
-                "description": "An optional string describing the cluster's endpoint.",
-                "examples": [
-                  "analytics-cluster.example.eu-west-1.redshift.amazonaws.com:5439/analytics"
-                ]
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "account",
-              "database",
-              "schema"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "AzureServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "azure"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "location": {
-                "type": "string",
-                "format": "uri",
-                "description": "Fully qualified path to Azure Blob Storage or Azure Data Lake Storage (ADLS), supports globs.",
-                "examples": [
-                  "az://my_storage_account_name.blob.core.windows.net/my_container/path/*.parquet",
-                  "abfss://my_storage_account_name.dfs.core.windows.net/my_container_name/path/*.parquet"
-                ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "parquet",
-                  "delta",
-                  "json",
-                  "csv"
-                ],
-                "description": "File format."
-              },
-              "delimiter": {
-                "type": "string",
-                "enum": [
-                  "new_line",
-                  "array"
-                ],
-                "description": "Only for format = json. How multiple json documents are delimited within one file"
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "location",
-              "format"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "SqlserverServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "sqlserver"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "host": {
-                "type": "string",
-                "description": "The host to the database server",
-                "examples": [
-                  "localhost"
-                ]
-              },
-              "port": {
-                "type": "integer",
-                "description": "The port to the database server.",
-                "default": 1433,
-                "examples": [
-                  1433
-                ]
-              },
-              "database": {
-                "type": "string",
-                "description": "The name of the database.",
-                "examples": [
-                  "database"
-                ]
-              },
-              "schema": {
-                "type": "string",
-                "description": "The name of the schema in the database.",
-                "examples": [
-                  "dbo"
-                ]
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "host",
-              "database",
-              "schema"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "SnowflakeServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "snowflake"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "account": {
-                "type": "string",
-                "description": "An optional string describing the server."
-              },
-              "database": {
-                "type": "string",
-                "description": "An optional string describing the server."
-              },
-              "schema": {
-                "type": "string",
-                "description": "An optional string describing the server."
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "account",
-              "database",
-              "schema"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "DatabricksServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "databricks",
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "host": {
-                "type": "string",
-                "description": "The Databricks host",
-                "examples": [
-                  "dbc-abcdefgh-1234.cloud.databricks.com"
-                ]
-              },
-              "catalog": {
-                "type": "string",
-                "description": "The name of the Hive or Unity catalog"
-              },
-              "schema": {
-                "type": "string",
-                "description": "The schema name in the catalog"
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "catalog",
-              "schema"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "DataframeServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "dataframe",
-                "description": "The type of the data product technology that implements the data contract."
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "GlueServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "glue",
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "account": {
-                "type": "string",
-                "description": "The AWS Glue account",
-                "examples": [
-                  "1234-5678-9012"
-                ]
-              },
-              "database": {
-                "type": "string",
-                "description": "The AWS Glue database name",
-                "examples": [
-                  "my_database"
-                ]
-              },
-              "location": {
-                "type": "string",
-                "format": "uri",
-                "description": "The AWS S3 path. Must be in the form of a URL.",
-                "examples": [
-                  "s3://datacontract-example-orders-latest/data/{model}"
-                ]
-              },
-              "format": {
-                "type": "string",
-                "description": "The format of the files",
-                "examples": [
-                  "parquet",
-                  "csv",
-                  "json",
-                  "delta"
-                ]
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "account",
-              "database"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "PostgresServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "postgres",
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "host": {
-                "type": "string",
-                "description": "The host to the database server",
-                "examples": [
-                  "localhost"
-                ]
-              },
-              "port": {
-                "type": "integer",
-                "description": "The port to the database server."
-              },
-              "database": {
-                "type": "string",
-                "description": "The name of the database.",
-                "examples": [
-                  "postgres"
-                ]
-              },
-              "schema": {
-                "type": "string",
-                "description": "The name of the schema in the database.",
-                "examples": [
-                  "public"
-                ]
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "host",
-              "port",
-              "database",
-              "schema"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "OracleServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "oracle",
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "host": {
-                "type": "string",
-                "description": "The host to the oracle server",
-                "examples": [
-                  "localhost"
-                ]
-              },
-              "port": {
-                "type": "integer",
-                "description": "The port to the oracle server.",
-                "examples": [
-                  1523
-                ]
-              },
-              "serviceName": {
-                "type": "string",
-                "description": "The name of the service.",
-                "examples": [
-                  "service"
-                ]
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "host",
-              "port",
-              "serviceName"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "KafkaServer",
-            "description": "Kafka Server",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "kafka"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "host": {
-                "type": "string",
-                "description": "The bootstrap server of the kafka cluster."
-              },
-              "topic": {
-                "type": "string",
-                "description": "The topic name."
-              },
-              "format": {
-                "type": "string",
-                "description": "The format of the message. Examples: json, avro, protobuf. Default: json.",
-                "default": "json"
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "host",
-              "topic"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "PubSubServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "pubsub"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "project": {
-                "type": "string",
-                "description": "The GCP project name."
-              },
-              "topic": {
-                "type": "string",
-                "description": "The topic name."
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "project",
-              "topic"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "KinesisDataStreamsServer",
-            "description": "Kinesis Data Streams Server",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "kinesis"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "stream": {
-                "type": "string",
-                "description": "The name of the Kinesis data stream."
-              },
-              "region": {
-                "type": "string",
-                "description": "AWS region.",
-                "examples": [
-                  "eu-west-1"
-                ]
-              },
-              "format": {
-                "type": "string",
-                "description": "The format of the record",
-                "examples": [
-                  "json",
-                  "avro",
-                  "protobuf"
-                ]
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "stream"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "TrinoServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "trino",
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "host": {
-                "type": "string",
-                "description": "The host to the database server",
-                "examples": [
-                  "localhost"
-                ]
-              },
-              "port": {
-                "type": "integer",
-                "description": "The port to the database server."
-              },
-              "catalog": {
-                "type": "string",
-                "description": "The name of the catalog.",
-                "examples": [
-                  "hive"
-                ]
-              },
-              "schema": {
-                "type": "string",
-                "description": "The name of the schema in the database.",
-                "examples": [
-                  "my_schema"
-                ]
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "host",
-              "port",
-              "catalog",
-              "schema"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "LocalServer",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "local"
-                ],
-                "description": "The type of the data product technology that implements the data contract."
-              },
-              "path": {
-                "type": "string",
-                "description": "The relative or absolute path to the data file(s).",
-                "examples": [
-                  "./folder/data.parquet",
-                  "./folder/*.parquet"
-                ]
-              },
-              "format": {
-                "type": "string",
-                "description": "The format of the file(s)",
-                "examples": [
-                  "json",
-                  "parquet",
-                  "delta",
-                  "csv"
-                ]
-              }
-            },
-            "additionalProperties": true,
-            "required": [
-              "type",
-              "path",
-              "format"
-            ]
+          "environment": {
+            "type": "string",
+            "description": "The environment in which the servers are running. Examples: prod, sit, stg."
           }
-        ]
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "object",
+              "title": "BigQueryServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "bigquery",
+                    "BigQuery"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "project": {
+                  "type": "string",
+                  "description": "An optional string describing the server."
+                },
+                "dataset": {
+                  "type": "string",
+                  "description": "An optional string describing the server."
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "project",
+                "dataset"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "S3Server",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "s3"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "location": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "An optional string describing the server. Must be in the form of a URL.",
+                  "examples": [
+                    "s3://datacontract-example-orders-latest/data/{model}/*.json"
+                  ]
+                },
+                "endpointUrl": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "The server endpoint for S3-compatible servers.",
+                  "examples": ["https://minio.example.com"]
+                },
+                "format": {
+                  "type": "string",
+                  "enum": [
+                    "parquet",
+                    "delta",
+                    "json",
+                    "csv"
+                  ],
+                  "description": "File format."
+                },
+                "delimiter": {
+                  "type": "string",
+                  "enum": [
+                    "new_line",
+                    "array"
+                  ],
+                  "description": "Only for format = json. How multiple json documents are delimited within one file"
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "location"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "GcsServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "gcs"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "location": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "The GS/GCS url to the data.",
+                  "examples": [
+                    "gs://example-storage/data/*/*.json"
+                  ]
+                },
+                "format": {
+                  "type": "string",
+                  "enum": [
+                    "parquet",
+                    "delta",
+                    "json",
+                    "csv"
+                  ],
+                  "description": "File format."
+                },
+                "delimiter": {
+                  "type": "string",
+                  "enum": [
+                    "new_line",
+                    "array"
+                  ],
+                  "description": "Only for format = json. How multiple json documents are delimited within one file"
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "location"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "SftpServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "sftp"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "location": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "An optional string describing the server. Must be in the form of a sftp URL.",
+                  "examples": [
+                    "sftp://123.123.12.123/{model}/*.json"
+                  ]
+                },
+                "format": {
+                  "type": "string",
+                  "enum": [
+                    "parquet",
+                    "delta",
+                    "json",
+                    "csv"
+                  ],
+                  "description": "File format."
+                },
+                "delimiter": {
+                  "type": "string",
+                  "enum": [
+                    "new_line",
+                    "array"
+                  ],
+                  "description": "Only for format = json. How multiple json documents are delimited within one file"
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "location"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "RedshiftServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "redshift"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "account": {
+                  "type": "string",
+                  "description": "An optional string describing the server."
+                },
+                "host": {
+                  "type": "string",
+                  "description": "An optional string describing the host name."
+                },
+                "database": {
+                  "type": "string",
+                  "description": "An optional string describing the server."
+                },
+                "schema": {
+                  "type": "string",
+                  "description": "An optional string describing the server."
+                },
+                "clusterIdentifier": {
+                  "type": "string",
+                  "description": "An optional string describing the cluster's identifier.",
+                  "examples": [
+                    "redshift-prod-eu",
+                    "analytics-cluster"
+                  ]
+                },
+                "port": {
+                  "type": "integer",
+                  "description": "An optional string describing the cluster's port.",
+                  "examples": [
+                    5439
+                  ]
+                },
+                "endpoint": {
+                  "type": "string",
+                  "description": "An optional string describing the cluster's endpoint.",
+                  "examples": [
+                    "analytics-cluster.example.eu-west-1.redshift.amazonaws.com:5439/analytics"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "account",
+                "database",
+                "schema"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "AzureServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "azure"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "location": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "Fully qualified path to Azure Blob Storage or Azure Data Lake Storage (ADLS), supports globs.",
+                  "examples": [
+                    "az://my_storage_account_name.blob.core.windows.net/my_container/path/*.parquet",
+                    "abfss://my_storage_account_name.dfs.core.windows.net/my_container_name/path/*.parquet"
+                  ]
+                },
+                "format": {
+                  "type": "string",
+                  "enum": [
+                    "parquet",
+                    "delta",
+                    "json",
+                    "csv"
+                  ],
+                  "description": "File format."
+                },
+                "delimiter": {
+                  "type": "string",
+                  "enum": [
+                    "new_line",
+                    "array"
+                  ],
+                  "description": "Only for format = json. How multiple json documents are delimited within one file"
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "location",
+                "format"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "SqlserverServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "sqlserver"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "host": {
+                  "type": "string",
+                  "description": "The host to the database server",
+                  "examples": [
+                    "localhost"
+                  ]
+                },
+                "port": {
+                  "type": "integer",
+                  "description": "The port to the database server.",
+                  "default": 1433,
+                  "examples": [
+                    1433
+                  ]
+                },
+                "database": {
+                  "type": "string",
+                  "description": "The name of the database.",
+                  "examples": [
+                    "database"
+                  ]
+                },
+                "schema": {
+                  "type": "string",
+                  "description": "The name of the schema in the database.",
+                  "examples": [
+                    "dbo"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "host",
+                "database",
+                "schema"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "SnowflakeServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "snowflake"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "account": {
+                  "type": "string",
+                  "description": "An optional string describing the server."
+                },
+                "database": {
+                  "type": "string",
+                  "description": "An optional string describing the server."
+                },
+                "schema": {
+                  "type": "string",
+                  "description": "An optional string describing the server."
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "account",
+                "database",
+                "schema"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "DatabricksServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "databricks",
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "host": {
+                  "type": "string",
+                  "description": "The Databricks host",
+                  "examples": [
+                    "dbc-abcdefgh-1234.cloud.databricks.com"
+                  ]
+                },
+                "catalog": {
+                  "type": "string",
+                  "description": "The name of the Hive or Unity catalog"
+                },
+                "schema": {
+                  "type": "string",
+                  "description": "The schema name in the catalog"
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "catalog",
+                "schema"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "DataframeServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "dataframe",
+                  "description": "The type of the data product technology that implements the data contract."
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "GlueServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "glue",
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "account": {
+                  "type": "string",
+                  "description": "The AWS Glue account",
+                  "examples": [
+                    "1234-5678-9012"
+                  ]
+                },
+                "database": {
+                  "type": "string",
+                  "description": "The AWS Glue database name",
+                  "examples": [
+                    "my_database"
+                  ]
+                },
+                "location": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "The AWS S3 path. Must be in the form of a URL.",
+                  "examples": [
+                    "s3://datacontract-example-orders-latest/data/{model}"
+                  ]
+                },
+                "format": {
+                  "type": "string",
+                  "description": "The format of the files",
+                  "examples": [
+                    "parquet",
+                    "csv",
+                    "json",
+                    "delta"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "account",
+                "database"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "PostgresServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "postgres",
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "host": {
+                  "type": "string",
+                  "description": "The host to the database server",
+                  "examples": [
+                    "localhost"
+                  ]
+                },
+                "port": {
+                  "type": "integer",
+                  "description": "The port to the database server."
+                },
+                "database": {
+                  "type": "string",
+                  "description": "The name of the database.",
+                  "examples": [
+                    "postgres"
+                  ]
+                },
+                "schema": {
+                  "type": "string",
+                  "description": "The name of the schema in the database.",
+                  "examples": [
+                    "public"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "host",
+                "port",
+                "database",
+                "schema"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "OracleServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "oracle",
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "host": {
+                  "type": "string",
+                  "description": "The host to the oracle server",
+                  "examples": [
+                    "localhost"
+                  ]
+                },
+                "port": {
+                  "type": "integer",
+                  "description": "The port to the oracle server.",
+                  "examples": [
+                    1523
+                  ]
+                },
+                "serviceName": {
+                  "type": "string",
+                  "description": "The name of the service.",
+                  "examples": [
+                    "service"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "host",
+                "port",
+                "serviceName"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "KafkaServer",
+              "description": "Kafka Server",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "kafka"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "host": {
+                  "type": "string",
+                  "description": "The bootstrap server of the kafka cluster."
+                },
+                "topic": {
+                  "type": "string",
+                  "description": "The topic name."
+                },
+                "format": {
+                  "type": "string",
+                  "description": "The format of the message. Examples: json, avro, protobuf. Default: json.",
+                  "default": "json"
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "host",
+                "topic"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "PubSubServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "pubsub"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "project": {
+                  "type": "string",
+                  "description": "The GCP project name."
+                },
+                "topic": {
+                  "type": "string",
+                  "description": "The topic name."
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "project",
+                "topic"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "KinesisDataStreamsServer",
+              "description": "Kinesis Data Streams Server",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "kinesis"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "stream": {
+                  "type": "string",
+                  "description": "The name of the Kinesis data stream."
+                },
+                "region": {
+                  "type": "string",
+                  "description": "AWS region.",
+                  "examples": [
+                    "eu-west-1"
+                  ]
+                },
+                "format": {
+                  "type": "string",
+                  "description": "The format of the record",
+                  "examples": [
+                    "json",
+                    "avro",
+                    "protobuf"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "stream"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "TrinoServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "trino",
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "host": {
+                  "type": "string",
+                  "description": "The host to the database server",
+                  "examples": [
+                    "localhost"
+                  ]
+                },
+                "port": {
+                  "type": "integer",
+                  "description": "The port to the database server."
+                },
+                "catalog": {
+                  "type": "string",
+                  "description": "The name of the catalog.",
+                  "examples": [
+                    "hive"
+                  ]
+                },
+                "schema": {
+                  "type": "string",
+                  "description": "The name of the schema in the database.",
+                  "examples": [
+                    "my_schema"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "host",
+                "port",
+                "catalog",
+                "schema"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "LocalServer",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "local"
+                  ],
+                  "description": "The type of the data product technology that implements the data contract."
+                },
+                "path": {
+                  "type": "string",
+                  "description": "The relative or absolute path to the data file(s).",
+                  "examples": [
+                    "./folder/data.parquet",
+                    "./folder/*.parquet"
+                  ]
+                },
+                "format": {
+                  "type": "string",
+                  "description": "The format of the file(s)",
+                  "examples": [
+                    "json",
+                    "parquet",
+                    "delta",
+                    "csv"
+                  ]
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "type",
+                "path",
+                "format"
+              ]
+            }
+          ]
+        }
       },
       "description": "Information about the servers."
     },


### PR DESCRIPTION
This commit modifies datacontract.schema.json to allow for many, named
servers, matching the wording of the data contract schema, the provided
examples, and the implementation of the datacontract-cli tool.