### PR TITLE
(README.md) Fix syntax within Lineage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,7 @@ models:
             - namespace: com.example.service.checkout
               name: checkout_db.orders
               field: order_timestamp
+              transformations:
                 - type: INDIRECT
                   subtype: SORT
       customer_email_address_hash:


### PR DESCRIPTION
Fixed an issue within the example syntax.

The elements 'type' and 'subtype' belong to the transformation object, per: https://datacontract.com/#transformation-object

This was correct for **order_id** but broken for **order_timestamp**.